### PR TITLE
Fix a critical bug & Allow message to show lost research's name

### DIFF
--- a/src/main/java/dev/walshy/hardcoreslimefun/events/Events.java
+++ b/src/main/java/dev/walshy/hardcoreslimefun/events/Events.java
@@ -21,7 +21,7 @@ public class Events implements Listener {
     @EventHandler
     public void onDeath(@Nonnull PlayerDeathEvent event) {
         PlayerProfile.get(event.getEntity(), profile -> {
-            final boolean shouldResetAllResearches = Utils.chance(Config.INSTANCE.getResearchFailChance());
+            final boolean shouldResetAllResearches = Utils.chance(Config.INSTANCE.getResetAllResearchesOnDeath());
 
             // If we should reset all researches, do it
             if (shouldResetAllResearches) {

--- a/src/main/java/dev/walshy/hardcoreslimefun/events/Events.java
+++ b/src/main/java/dev/walshy/hardcoreslimefun/events/Events.java
@@ -36,7 +36,8 @@ public class Events implements Listener {
                 if (randomResearch == null) return;
 
                 profile.setResearched(randomResearch, false);
-                Utils.send(event.getEntity(), Config.INSTANCE.getLostRandomResearch());
+                String message = Config.INSTANCE.getLostRandomResearch().replace("%research%", randomResearch.getName(event.getEntity()));
+                Utils.send(event.getEntity(), message);
             }
         });
     }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -20,6 +20,7 @@ android:
   malfunction-duration: 30
 
 messages:
+  # %research% can be used to show the lost research's name
   lost-random-research: '&cYou lost a random research!'
   lost-all-research: '&cOh noes... You lost all your research!'
   research-failed: '&cResearch failed! You''ll need to do that again :^)'


### PR DESCRIPTION
Some players want to know what research they lost on death, so I added a variable `%research%` to display the lost research's name in the message.

**CRITICAL** The player will lose all researches on death even when chance is 0, this is because the research fail chance is used. I fixed this bug.